### PR TITLE
except AttributeError was logging incorrect error message

### DIFF
--- a/sqlitebiter/sqlitebiter.py
+++ b/sqlitebiter/sqlitebiter.py
@@ -460,9 +460,6 @@ def gs(ctx, credentials, title, output_path):
     except ptr.OpenError as e:
         logger.error(msgfy.to_error_message(e))
         result_counter.inc_fail()
-    except AttributeError:
-        logger.error(u"invalid credentials data: path={}".format(credentials))
-        result_counter.inc_fail()
     except (ptr.ValidationError, ptr.DataError) as e:
         logger.error(u"invalid credentials data: path={}, message={}".format(
             credentials, str(e)))


### PR DESCRIPTION
When I remove this catch block
```py
except AttributeError:
     logger.error(u"invalid credentials data: path={}".format(credentials))
     result_counter.inc_fail()
```
The error shown suggests that it's not related to malformatted credentials, so I think the `except` block should be removed until it can communicate the correct error to the logger or user. Below is the stack trace that is shown with the change in the branch for this PR:

```sh
❯ sqlitebiter gs ./my-oauth-creds.json my-spreadsheet -o my-db.sqlite
Traceback (most recent call last):
  File "/usr/local/bin/sqlitebiter", line 11, in <module>
    sys.exit(cmd())
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/sqlitebiter/sqlitebiter.py", line 453, in gs
    for logger.warnlogger.warntable_data in warndata:
  File "/usr/local/lib/python2.7/site-packages/pytablereader/spreadsheet/gsloader.py", line 119, in load
    dp_extractor=self._loader.dp_extractor)
AttributeError: 'GoogleSheetsTableLoader' object has no attribute '_loader'
```