### PR TITLE
Fix Installation: dpkg (.deb package)

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -7,7 +7,7 @@ if [ $UID -ne 0 ]; then
     exit 13
 fi
 
-ARCHIVE_URL=$(curl -sSL https://api.github.com/repos/thombashi/sqlitebiter/releases/latest | jq -r '.assets[].browser_download_url' | \grep deb)
+ARCHIVE_URL=$(curl -sSL https://api.github.com/repos/thombashi/sqlitebiter/releases/latest | jq -r '.assets[].browser_download_url' | \grep bionic_amd64.deb)
 TEMP_DEB="$(mktemp)"
 
 trap "\rm -f $TEMP_DEB" 0 1 2 3 15

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -7,7 +7,11 @@ if [ $UID -ne 0 ]; then
     exit 13
 fi
 
-ARCHIVE_URL=$(curl -sSL https://api.github.com/repos/thombashi/sqlitebiter/releases/latest | jq -r '.assets[].browser_download_url' | \grep bionic_amd64.deb)
+ARCH=$(dpkg --print-architecture)
+CODENAME=$(lsb_release -c | awk '{print $2}')
+DEBFILE=$CODENAME\_$ARCH\.deb
+
+ARCHIVE_URL=$(curl -sSL https://api.github.com/repos/thombashi/sqlitebiter/releases/latest | jq -r '.assets[].browser_download_url' | \grep $DEBFILE)
 TEMP_DEB="$(mktemp)"
 
 trap "\rm -f $TEMP_DEB" 0 1 2 3 15


### PR DESCRIPTION
Currently, the $ARCHIVE_URL var is holding two URLs instead of fetching only one, making the script fail:

```
curl: (3) URL using bad/illegal format or missing URL
```

$ARCHIVE_URL value:

https://github.com/thombashi/sqlitebiter/releases/download/v0.36.1/sqlitebiter_0.36.1_bionic_amd64.deb https://github.com/thombashi/sqlitebiter/releases/download/v0.36.1/sqlitebiter_0.36.1_focal_amd64.deb

Please check [here](https://api.github.com/repos/thombashi/sqlitebiter/releases/latest). 